### PR TITLE
Fix long leap rewind on large videos

### DIFF
--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/mod/leanback/playerglue/PlaybackTransportRowPresenter.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/mod/leanback/playerglue/PlaybackTransportRowPresenter.java
@@ -46,6 +46,7 @@ import com.liskovsoft.smartyoutubetv2.tv.ui.mod.leanback.playerglue.ControlBarPr
 import com.liskovsoft.smartyoutubetv2.tv.ui.mod.leanback.playerglue.MaxIconNumVideoPlayerGlue.OnQualityInfoCallback;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A PlaybackTransportRowPresenter renders a {@link PlaybackControlsRow} to display a
@@ -68,6 +69,7 @@ public class PlaybackTransportRowPresenter extends PlaybackRowPresenter {
      * A ViewHolder for the PlaybackControlsRow supporting seek UI.
      */
     public class ViewHolder extends PlaybackRowPresenter.ViewHolder implements PlaybackSeekUi {
+        private final long TEN_SECONDS = TimeUnit.SECONDS.toMillis(10);
         final Presenter.ViewHolder mDescriptionViewHolder;
         final ImageView mImageView;
         final ViewGroup mDescriptionDock;
@@ -169,7 +171,7 @@ public class PlaybackTransportRowPresenter extends PlaybackRowPresenter {
                 }
                 updateThumbsInSeek(thumbHeroIndex, forward);
             } else {
-                long interval = (long) (mTotalTimeInMs * getDefaultSeekIncrement());
+                long interval = TEN_SECONDS;
                 newPos = pos + (forward ? interval : -interval);
                 if (newPos > mTotalTimeInMs) {
                     newPos = mTotalTimeInMs;


### PR DESCRIPTION
I faced an issue with long jumps when press FAST_FORWARD (and MEDIA_REWIND) button on video playback. For example on 2 hours video pressing forward button 1 time skips something like 2 minutes. 
This PR changes a playback jump to a standard (for youtube client) 10 seconds.