### PR TITLE
Disable filler category by default

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/ContentBlockData.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/ContentBlockData.java
@@ -225,7 +225,11 @@ public class ContentBlockData {
         // Easy add new segments
         for (String segmentCategory : mAllCategories) {
             if (getAction(segmentCategory) == ACTION_UNDEFINED) {
-                mActions.add(SegmentAction.from(segmentCategory, ACTION_SKIP_WITH_TOAST));
+                if (SponsorSegment.CATEGORY_FILLER.equals(segmentCategory)) {
+                    mActions.add(SegmentAction.from(segmentCategory, ACTION_DO_NOTHING));
+                } else {
+                    mActions.add(SegmentAction.from(segmentCategory, ACTION_SKIP_WITH_TOAST));
+                }
             }
         }
     }


### PR DESCRIPTION
This category is very extreme [and is recommended to be disabled by default](https://wiki.sponsor.ajay.app/w/Types#:~:text=Warning%3A%20the%20filler%20category%20is%20very%20aggressive) because of that. I've received several messages being confused about SponsorBlock due to filler being enabled by default on SmartTubeNext, so would appreciate this change being merged :)

I have tested this locally