### PR TITLE
Dependency updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle" 
+    directory: "/" 
+    schedule:
+      interval: "daily"
+
+    # Try to remove the PR limit
+    open-pull-requests-limit: 999

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.4'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:' + kotlinVersion
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/chatkit/build.gradle
+++ b/chatkit/build.gradle
@@ -49,6 +49,6 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:' + appCompatXLibraryVersion
     implementation 'com.google.android.material:material:1.6.1'
-    implementation "com.google.android:flexbox:1.0.0"
+    implementation "com.google.android:flexbox:2.0.1"
     implementation 'androidx.recyclerview:recyclerview:' + recyclerviewXLibraryVersion
 }

--- a/chatkit/build.gradle
+++ b/chatkit/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation project(':sharedutils')
 
     implementation 'androidx.appcompat:appcompat:' + appCompatXLibraryVersion
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'com.google.android.material:material:1.6.1'
     implementation "com.google.android:flexbox:1.0.0"
     implementation 'androidx.recyclerview:recyclerview:' + recyclerviewXLibraryVersion
 }

--- a/smarttubetv/build.gradle
+++ b/smarttubetv/build.gradle
@@ -166,7 +166,7 @@ dependencies {
 
     implementation 'com.github.bumptech.glide:glide:' + glideVersion
     annotationProcessor 'com.github.bumptech.glide:compiler:' + glideVersion
-    implementation 'com.zlc.glide:webpdecoder:2.0.' + glideVersion
+    implementation 'com.zlc.glide:webpdecoder:2.0.4.12.0' + glideVersion
 
     //////// BEGIN EXOPLAYER /////////
 

--- a/smarttubetv/build.gradle
+++ b/smarttubetv/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
         // Check that you have the Google Services Gradle plugin v4.3.2 or later
         // (if not, add it).
-        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.gms:google-services:4.3.13'
 
         // Add the Crashlytics Gradle plugin.
         // https://firebase.google.com/docs/crashlytics/get-started?platform=android

--- a/smarttubetv/build.gradle
+++ b/smarttubetv/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         // Add the Crashlytics Gradle plugin.
         // https://firebase.google.com/docs/crashlytics/get-started?platform=android
         // https://firebase.google.com/docs/android/setup
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.1'
     }
 }
 


### PR DESCRIPTION
Added a Dependabot config if you wish to activate Dependabot on the Master github. Along with this, 6 dependencies were updated.

Dependency updates:

- firebase-crashlytics-gradle: 2.7.1 -> 2.9.1
- flexbox: 1.0.0 -> 2.0.1
- google-services: 4.3.10 -> 4.3.13
- gradle: 3.5.4 -> 7.2.2 (Almost 5 years outdated!?)
- material: 1.2.1 -> 1.6.1
- webpdecoder: 2.0 -> 2.0.4.12.0