### PR TITLE
Support for time parameter when opening a link via the app

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/PlaybackPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/PlaybackPresenter.java
@@ -49,14 +49,14 @@ public class PlaybackPresenter extends BasePresenter<PlaybackView> {
     /**
      * Opens video item from splash view
      */
-    public void openVideo(String videoId, boolean finishOnEnded, Integer timeMs) {
+    public void openVideo(String videoId, boolean finishOnEnded, Long timeMs) {
         if (videoId == null) {
             return;
         }
 
         Video video = Video.from(videoId);
         video.finishOnEnded = finishOnEnded;
-        video.pendingPosMs = timeMs;
+        video.pendingPosMs = timeMs == null ? 0 : timeMs;
         openVideo(video);
     }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/PlaybackPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/PlaybackPresenter.java
@@ -49,13 +49,14 @@ public class PlaybackPresenter extends BasePresenter<PlaybackView> {
     /**
      * Opens video item from splash view
      */
-    public void openVideo(String videoId, boolean finishOnEnded) {
+    public void openVideo(String videoId, boolean finishOnEnded, Integer time) {
         if (videoId == null) {
             return;
         }
 
         Video video = Video.from(videoId);
         video.finishOnEnded = finishOnEnded;
+        video.pendingPosMs = time == null ? 0 : time * 1000;
         openVideo(video);
     }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/PlaybackPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/PlaybackPresenter.java
@@ -49,14 +49,14 @@ public class PlaybackPresenter extends BasePresenter<PlaybackView> {
     /**
      * Opens video item from splash view
      */
-    public void openVideo(String videoId, boolean finishOnEnded, Integer time) {
+    public void openVideo(String videoId, boolean finishOnEnded, Integer timeMs) {
         if (videoId == null) {
             return;
         }
 
         Video video = Video.from(videoId);
         video.finishOnEnded = finishOnEnded;
-        video.pendingPosMs = time == null ? 0 : time * 1000;
+        video.pendingPosMs = timeMs;
         openVideo(video);
     }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/SplashPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/SplashPresenter.java
@@ -242,9 +242,9 @@ public class SplashPresenter extends BasePresenter<SplashView> {
                     viewManager.setSinglePlayerMode(true);
                 }
 
-                String time = IntentExtractor.extractVideoTime(intent);
+                Long timeMs = IntentExtractor.extractVideoTimeMs(intent);
                 PlaybackPresenter playbackPresenter = PlaybackPresenter.instance(getContext());
-                playbackPresenter.openVideo(videoId, IntentExtractor.hasFinishOnEndedFlag(intent), time);
+                playbackPresenter.openVideo(videoId, IntentExtractor.hasFinishOnEndedFlag(intent), timeMs);
 
                 return true;
             }

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/SplashPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/SplashPresenter.java
@@ -242,8 +242,9 @@ public class SplashPresenter extends BasePresenter<SplashView> {
                     viewManager.setSinglePlayerMode(true);
                 }
 
+                String time = IntentExtractor.extractVideoTime(intent);
                 PlaybackPresenter playbackPresenter = PlaybackPresenter.instance(getContext());
-                playbackPresenter.openVideo(videoId, IntentExtractor.hasFinishOnEndedFlag(intent));
+                playbackPresenter.openVideo(videoId, IntentExtractor.hasFinishOnEndedFlag(intent), time);
 
                 return true;
             }
@@ -256,7 +257,7 @@ public class SplashPresenter extends BasePresenter<SplashView> {
 
             if (backupData != null) {
                 PlaybackPresenter playbackPresenter = PlaybackPresenter.instance(getContext());
-                playbackPresenter.openVideo(backupData, false);
+                playbackPresenter.openVideo(backupData, false, null);
                 return true;
             }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/IntentExtractor.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/IntentExtractor.java
@@ -14,6 +14,7 @@ public class IntentExtractor {
      */
     private static final String[] SEARCH_KEYS = {"search_query", "query"};
     private static final String VIDEO_ID_KEY = "v";
+    private static final String VIDEO_TIME_KEY = "t";
     private static final String VIDEO_ID_LIST_KEY = "video_ids";
     /**
      * https://youtube.com/channel/BLABLA/video
@@ -25,6 +26,21 @@ public class IntentExtractor {
     private static final String HISTORY_URL = "https://www.youtube.com/tv#/zylon-surface?c=FEmy_youtube"; // last 'resume' param isn't parsed by intent and should be removed
     private static final String RECOMMENDED_URL = "https://www.youtube.com/tv#/zylon-surface?c=default"; // last 'resume' param isn't parsed by intent and should be removed
     private static final String PLAYLIST_KEY = "list";
+
+    public static Integer extractVideoTime(Intent intent) {
+        if (isEmptyIntent(intent)) {
+            return null;
+        }
+
+        UrlQueryString parser = UrlQueryStringFactory.parse(extractUri(intent));
+        String time = parser.get(VIDEO_TIME_KEY);
+
+        try {
+            return Integer.parseInt(time);
+        } catch (Exception e) {
+            return null;
+        }
+    }
 
     public static String extractVideoId(Intent intent) {
         if (isEmptyIntent(intent)) {

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/IntentExtractor.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/IntentExtractor.java
@@ -27,17 +27,37 @@ public class IntentExtractor {
     private static final String RECOMMENDED_URL = "https://www.youtube.com/tv#/zylon-surface?c=default"; // last 'resume' param isn't parsed by intent and should be removed
     private static final String PLAYLIST_KEY = "list";
 
-    public static Integer extractVideoTime(Intent intent) {
+    public static Long extractVideoTimeMs(Intent intent) {
         if (isEmptyIntent(intent)) {
             return null;
         }
 
         UrlQueryString parser = UrlQueryStringFactory.parse(extractUri(intent));
         String time = parser.get(VIDEO_TIME_KEY);
+        if (time == null) {
+            return null;
+        }
+
+        long multiplier = 1;
+        if (time.endsWith("ms")) {
+            time = time.substring(0, time.length() - 2);
+        } else if (time.endsWith("s")) {
+            multiplier = 1000;
+            time = time.substring(0, time.length() - 1);
+        } else if (time.endsWith("m")) {
+            multiplier = 60 * 1000;
+            time = time.substring(0, time.length() - 1);
+        } else if (time.endsWith("h")) {
+            multiplier = 60 * 60 * 1000;
+            time = time.substring(0, time.length() - 1);
+        } else {
+            // Assume seconds if no time unit suffix is present
+            multiplier = 1000;
+        }
 
         try {
-            return Integer.parseInt(time);
-        } catch (Exception e) {
+            return multiplier * Long.parseLong(time);
+        } catch (NumberFormatException e) {
             return null;
         }
     }


### PR DESCRIPTION
Currently, this commend will start the video from the beginning despite the time flag. This fixes it. I added support for `ms`,`s`,`h` and no unit as it seems to be the only formats that youtube currently supports.

```
adb shell am start -a android.intent.action.VIEW -d "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=5s" -n com.teamsmart.videomanager.tv/com.liskovsoft.smartyoutubetv2.tv.ui.main.SplashActivity
```

If anyone is able to build the app to verify it is working it would be great, as I was unable to get passed the `google_config.json` file. You pretty much just need to connect via adb and paste this shell command to confirm it is functional