### PR TITLE
Support x86 ABI

### DIFF
--- a/smarttubetv/build.gradle
+++ b/smarttubetv/build.gradle
@@ -71,8 +71,7 @@ android {
         // https://stackoverflow.com/questions/37382057/android-apk-how-to-exclude-a-so-file-from-a-3rd-party-dependency-using-gradle
         // armeabi-v7a backward compatible with arm64-v8a, x86 -> x86_64 etc
         ndk {
-            abiFilters "armeabi-v7a"
-            //abiFilters "armeabi-v7a", "x86"
+            abiFilters "armeabi-v7a", "x86"
             //abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
         }
     }


### PR DESCRIPTION
While Android running on x86 hardware can run this app using ARM native bridge solution, not everyone want to use them because they are not open-source. Also it's better to just run native libraries rather than going through a translation process.